### PR TITLE
Fix authorization error

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ To run this code on your local machine:
 2. Clone the repo:
   
   ```bash
-  git clone --single-branch -b starter-template https://github.com/kimanikevin254/descope-panel-auth-sso.git
+  git clone https://github.com/kimanikevin254/descope-panel-auth-sso.git
   ```
 3. Create and activate a virtual environment:
 

--- a/main.py
+++ b/main.py
@@ -14,7 +14,7 @@ def authorize(user_info):
     Authorization callback to redirect users based on roles.
     """
     # Extract user roles from the user_info dict
-    roles = user_info.get('tenants').get(os.getenv('DESCOPE_TENANT_ID'), {}).get('roles')
+    roles = user_info.get('tenants', {}).get(os.getenv('DESCOPE_TENANT_ID'), {}).get('roles', [])
 
     if "Tenant Admin" in roles:
         return "/admin"


### PR DESCRIPTION
Only those who log in with Okta will have an associated tenant. The existing code breaks the social login and magic links.